### PR TITLE
BUILD-TRANSPARENCY-MAP not called for images with tRNS

### DIFF
--- a/ancillary-chunks.lisp
+++ b/ancillary-chunks.lisp
@@ -50,9 +50,7 @@
                               (big-endian-vector-to-integer (subseq chunk-data 4 6)))))
     (:indexed-colour (setf (transparency *png-state*)
                            chunk-data)))
-  (when (or (eql (colour-type *png-state*) 0)
-            (eql (colour-type *png-state*) 2))
-    (push #'build-transparency-map (postprocess-ancillaries *png-state*))))
+  (push #'build-transparency-map (postprocess-ancillaries *png-state*)))
 
 (defmethod parse-ancillary-chunk ((chunk-type (eql '|gAMA|)) chunk-data)
   (setf (gamma *png-state*)


### PR DESCRIPTION
tRNS method sets (TRANSPARENCY _PNG-STATE_) to some raw data
representation depending on colour-type. Then it adds
so (TRANSPARENCY _PNG-STATE_) will become a 2D-array
before _png-state_ is finished.

The latter part (adding the postprocessor) was inside an incorrect
WHEN form, requiring (COLOUR-TYPE _PNG-STATE_) to be 0 or 2. First,
our COLOUR-TYPE is a keyword, not a byte (thus 0 and 2 correspond to
:greyscale and :truecolor, respectively). Second,
build-transparency-map is prepared to handle :indexed-colour images as
well, and there are images where it's useful. Third, preceding ECASE
will fail for any colour-type except :greyscale, :truecolor and
:indexed-colour.

Therefore it seems that no additional checks are needed here at all,
and that's the assumption behind this patch.
